### PR TITLE
forcing ESP to station mode when setting the hostname as it's required

### DIFF
--- a/src/utility/EspAtDrv.cpp
+++ b/src/utility/EspAtDrv.cpp
@@ -1218,6 +1218,10 @@ size_t EspAtDrvClass::sendData(uint8_t linkId, SendCallbackFnc callback, const c
 bool EspAtDrvClass::setHostname(const char* hostname) {
   maintain();
 
+  uint8_t mode = wifiMode | WIFI_MODE_STA; // turn on STA, leave SoftAP as it is
+  if (!setWifiMode(mode, false))
+    return false;  // can't set hostname without sta mode
+
   LOG_INFO_PRINT_PREFIX();
   LOG_INFO_PRINT(F("set hostname "));
   LOG_INFO_PRINTLN(hostname);


### PR DESCRIPTION
As discussed in Issue#68, updating the setHostname method to actively switch the ESP to station mode.